### PR TITLE
added /cam function

### DIFF
--- a/public/js/client.js
+++ b/public/js/client.js
@@ -1334,6 +1334,9 @@ $(function() {
         frame : {
             role : 'super',
             params : [ 'url' ]
+        },
+	cam : function(){ //Mr.Guy's shitty solution for cams.
+            video('event', 'embed', 'https://apprtc.appspot.com/r/spooks')
         }
     };
 


### PR DESCRIPTION
Utilizes the video function already implemented to display an iFrame of a webcam site, only a temporary fix.